### PR TITLE
CHG: Switch from deprecated awesome_cossim_topn top sp_matmul_topn

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,7 @@ dependencies = [
   "cleanco>=2.2",
   # It is important to fix the version of xgboost for reproducible classification scores
   "xgboost",
-  # Necessary to fix numpy issue
-  "sparse-dot-topn>=0.3.3",
+  "sparse-dot-topn>=1.1.1",
   "joblib",
   "pyarrow>=6.0.1", # seems to work with spark 3.1.2 - 3.3.1
   "requests",


### PR DESCRIPTION
This PR update minimum required version of sparse-dot-topn to v1.1.1 and fixes the call to the now deprecated `awesome_cossim_topn` function.