### PR TITLE
ENH: several small fixes and updates

### DIFF
--- a/emm/aggregation/base_entity_aggregation.py
+++ b/emm/aggregation/base_entity_aggregation.py
@@ -141,6 +141,7 @@ class BaseEntityAggregation(Pipeline):
         preprocessed_col: str = "preprocessed",
         gt_name_col: str = "gt_name",
         gt_preprocessed_col: str = "gt_preprocessed",
+        correct_col: str = "correct",
         aggregation_method: Literal["max_frequency_nm_score", "mean_score"] = "max_frequency_nm_score",
         blacklist: list | None = None,
         positive_set_col: str = "positive_set",
@@ -157,6 +158,7 @@ class BaseEntityAggregation(Pipeline):
         self.preprocessed_col = preprocessed_col
         self.gt_name_col = gt_name_col
         self.gt_preprocessed_col = gt_preprocessed_col
+        self.correct_col = correct_col
         self.aggregation_method = aggregation_method
         self.blacklist = blacklist or []
         self.positive_set_col = positive_set_col

--- a/emm/aggregation/pandas_entity_aggregation.py
+++ b/emm/aggregation/pandas_entity_aggregation.py
@@ -45,6 +45,7 @@ class PandasEntityAggregation(TransformerMixin, BaseEntityAggregation):
         preprocessed_col: str = "preprocessed",
         gt_name_col: str = "gt_name",
         gt_preprocessed_col: str = "gt_preprocessed",
+        correct_col: str = "correct",
         aggregation_method: Literal["max_frequency_nm_score", "mean_score"] = "max_frequency_nm_score",
         blacklist: list[str] | None = None,
     ) -> None:
@@ -80,6 +81,7 @@ class PandasEntityAggregation(TransformerMixin, BaseEntityAggregation):
             preprocessed_col: Name of column of preprocessed input
             gt_name_col: ground truth name column, default is "gt_name".
             gt_preprocessed_col: column name of preprocessed ground truth names, default is "preprocessed".
+            correct_col: column indicating correct matches, if present. default is "correct". optional.
             aggregation_method: default is "max_frequency_nm_score", alternative is "mean_score".
             blacklist: blacklist of names to skip in clustering.
         """
@@ -97,6 +99,7 @@ class PandasEntityAggregation(TransformerMixin, BaseEntityAggregation):
             preprocessed_col=preprocessed_col,
             gt_name_col=gt_name_col,
             gt_preprocessed_col=gt_preprocessed_col,
+            correct_col=correct_col,
             aggregation_method=aggregation_method,
             blacklist=blacklist or [],
         )

--- a/emm/helper/spark_custom_reader_writer.py
+++ b/emm/helper/spark_custom_reader_writer.py
@@ -214,6 +214,30 @@ class SparkCustomWriter(MLWriter):
         }
         return json.dumps(metadata, separators=[",", ":"])
 
+    def format(self, file_format: str):
+        """Set the file format of ground truth datasets that are saved
+
+        Args:
+            file_format: storage format of spark dataframes, default is parquet.
+
+        Returns:
+            self
+        """
+        self.file_format = file_format
+        return self
+
+    def options(self, **kwargs):
+        """Set the other file storage options of ground truth datasets that are saved
+
+        Args:
+            kwargs: storage kw-args, passed on to: sdf.write.save(path, format=self.file_format, **self.kwargs)
+
+        Returns:
+            self
+        """
+        self.store_kws = kwargs
+        return self
+
 
 class SparkCustomReader(MLReader):
     """Spark Custom class reader"""

--- a/emm/indexing/pandas_normalized_tfidf.py
+++ b/emm/indexing/pandas_normalized_tfidf.py
@@ -162,9 +162,10 @@ class PandasNormalizedTfidfVectorizer(TfidfVectorizer):
         if effective_n_jobs(n_jobs) == 1:
             return self.transform(X=X)
 
+        chunk_size = int(np.ceil(len(X) / effective_n_jobs(n_jobs)))
+        X_chunks = [X.iloc[i : i + chunk_size] for i in range(0, len(X), chunk_size)]
+
         transform_splits = Parallel(n_jobs=n_jobs, backend="threading")(
-            delayed(self.transform)(X_split)
-            for X_split in np.array_split(X, effective_n_jobs(n_jobs))
-            if len(X_split) > 0
+            delayed(self.transform)(X_split) for X_split in X_chunks if len(X_split) > 0
         )
         return sp.vstack(transform_splits)

--- a/emm/preprocessing/base_name_preprocessor.py
+++ b/emm/preprocessing/base_name_preprocessor.py
@@ -36,6 +36,7 @@ DEFINED_PIPELINE_DICT = {
         "remove_newline",
         "strip_punctuation",  # normal way: remove punctuation, handle unicode, lower and trim
         "handle_lower_trim",
+        "remove_extra_space",
     ],
     "preprocess_with_punctuation": [
         "strip_accents_unicode",
@@ -43,6 +44,7 @@ DEFINED_PIPELINE_DICT = {
         "remove_newline",
         "insert_space_around_punctuation",  # punctuation will be kept. Must be work with
         "handle_lower_trim",
+        "remove_extra_space",
     ],
     "preprocess_merge_abbr": [
         "strip_accents_unicode",
@@ -53,6 +55,7 @@ DEFINED_PIPELINE_DICT = {
         "strip_punctuation",
         "handle_lower_trim",
         "map_shorthands",
+        "remove_extra_space",
     ],
     "preprocess_merge_legal_abbr": [
         "strip_accents_unicode",

--- a/emm/preprocessing/pandas_preprocessor.py
+++ b/emm/preprocessing/pandas_preprocessor.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 from functools import partial
 from typing import Any, Callable, Mapping
 
-import numpy as np
 import pandas as pd
 from sklearn.base import TransformerMixin
 
@@ -109,10 +108,11 @@ class PandasPreprocessor(TransformerMixin, AbstractPreprocessor):
     ) -> pd.Series:
         # Remark: 'chunk_size' is not the same as 'partition_size'
         # because here we just do name preprocessing and that can be done with much larger partitions
-        # than 'partition_size' that is designed to handle the fact that cosine similarity creates 10 times more data after the candidate generation
+        # than 'partition_size' that is designed to handle the fact that cosine similarity creates 10 times more data
+        # after the candidate generation
 
         with Timer("PandasPreprocessor._spark_apply_steps") as timer:
-            X_chunks = np.array_split(series, (len(series) + chunk_size - 1) // chunk_size)
+            X_chunks = [series.iloc[i : i + chunk_size] for i in range(0, len(series), chunk_size)]
             sc = self.spark_session.sparkContext
             rdd = sc.parallelize(X_chunks, len(X_chunks))
 

--- a/tests/integration/test_indexers.py
+++ b/tests/integration/test_indexers.py
@@ -216,7 +216,7 @@ def test_indexer_objects_pandas(kvk_training_dataset):
     p.fit(gt)
     res = p.transform(names)
 
-    assert len(res) == 118
+    assert len(res) == 117
 
 
 @pytest.mark.skipif(not spark_installed, reason="spark not found")
@@ -239,7 +239,7 @@ def test_indexer_objects_spark(kvk_training_dataset, spark_session):
     p.fit(sgt)
     res = p.transform(snames)
 
-    assert res.count() == 118
+    assert res.count() == 117
 
 
 def test_naive_indexer_pandas(kvk_training_dataset):

--- a/tests/integration/test_supervised.py
+++ b/tests/integration/test_supervised.py
@@ -142,7 +142,7 @@ def test_return_sm_features_pandas(kvk_training_dataset):
         "X_feat_score_0_diff_to_prev",
     ]
 
-    assert len(res) == 118
+    assert len(res) == 117
     assert all(feat in res.columns for feat in features)
     assert (res["X_feat_norm_jaro"] > 0).all()
 
@@ -202,5 +202,5 @@ def test_return_sm_features_spark(kvk_training_dataset, spark_session):
         "X_feat_score_0_diff_to_prev",
     ]
 
-    assert res.count() == 118
+    assert res.count() == 117
     assert all(feat in res.columns for feat in features)

--- a/tests/integration/test_training_classifier.py
+++ b/tests/integration/test_training_classifier.py
@@ -48,7 +48,7 @@ def test_increase_window_pandas(kvk_training_dataset):
 
     p.increase_window_by_one_step()
     res = p.transform(names)
-    assert len(res) == 327
+    assert len(res) == 324
     assert res["rank_0"].max() == 11
     assert res["rank_1"].max() == 3
     assert res["rank_1"].min() == -3
@@ -73,7 +73,7 @@ def test_decrease_window_pandas(kvk_training_dataset):
 
     p.decrease_window_by_one_step()
     res = p.transform(names)
-    assert len(res) == 227
+    assert len(res) == 226
     assert res["rank_0"].max() == 9
     assert res["rank_1"].max() == 1
     assert res["rank_1"].min() == -1
@@ -102,7 +102,7 @@ def test_increase_window_spark(kvk_training_dataset, spark_session):
 
     p.increase_window_by_one_step()
     res = p.transform(snames)
-    assert res.count() == 327
+    assert res.count() == 324
 
 
 @pytest.mark.skipif(not spark_installed, reason="spark not found")
@@ -128,7 +128,7 @@ def test_decrease_window_spark(kvk_training_dataset, spark_session):
 
     p.decrease_window_by_one_step()
     res = p.transform(snames)
-    assert res.count() == 227
+    assert res.count() == 226
 
 
 def test_create_name_pairs_pandas(kvk_training_dataset):
@@ -151,13 +151,13 @@ def test_create_name_pairs_pandas(kvk_training_dataset):
     train = p.create_training_name_pairs(names, create_negative_sample_fraction=0.5, random_seed=42)
 
     assert isinstance(train, pd.DataFrame)
-    assert len(train) == 277
+    assert len(train) == 274
     assert "correct" in train.columns
     assert "no_candidate" in train.columns
     assert "positive_set" in train.columns
     vc = train["positive_set"].value_counts().to_dict()
-    assert vc[False] == 152
-    assert vc[True] == 125
+    assert vc[False] == 148
+    assert vc[True] == 126
 
 
 @pytest.mark.skipif(not spark_installed, reason="spark not found")
@@ -184,13 +184,13 @@ def test_create_name_pairs_spark(kvk_training_dataset, spark_session):
     train = p.create_training_name_pairs(snames, create_negative_sample_fraction=0.5, random_seed=42)
 
     assert isinstance(train, pd.DataFrame)
-    assert len(train) == 277
+    assert len(train) == 274
     assert "correct" in train.columns
     assert "no_candidate" in train.columns
     assert "positive_set" in train.columns
     vc = train["positive_set"].value_counts().to_dict()
-    assert vc[False] == 152
-    assert vc[True] == 125
+    assert vc[False] == 148
+    assert vc[True] == 126
 
 
 def test_fit_classifier_pandas(kvk_training_dataset):

--- a/tests/unit/test_name_preprocessing.py
+++ b/tests/unit/test_name_preprocessing.py
@@ -56,13 +56,13 @@ THIS_DIR = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe(
         (
             "preprocess_name",
             ["Tzu-Sun_BV.a;b,c_ä", "Tzu-Sun_BV  morethan1space"],
-            ["tzu sun bv a b c a", "tzu sun bv  morethan1space"],
+            ["tzu sun bv a b c a", "tzu sun bv morethan1space"],
         ),
         ("preprocess_with_punctuation", ["Tzu-Sun_BV.a;b,c_ä"], ["tzu - sun _ bv . a ; b , c _ a"]),
         (
             "preprocess_merge_abbr",
             ["Tzu-Sun_B.V.a;b,c_ä", "Z. S. B. V.", "Z Sun B V", "Z. Sun B.V.", "Z Sun B.V"],
-            ["tzu sun b v a b c a", "zsbv", "z sun bv", "z  sun bv", "z sun bv"],
+            ["tzu sun b v a b c a", "zsbv", "z sun bv", "z sun bv", "z sun bv"],
         ),
         (
             "preprocess_merge_legal_abbr",
@@ -193,9 +193,9 @@ def test_preprocessor_pandas_unusual_chars():
     out = pandas_preprocessor.transform(df)["preprocessed"].tolist()
     expect = [
         "b n consult b v",
-        "stichting vrienden van laurens  pax intrantibus",
-        "nicren  n v",
-        "scheepvaartbedrijf absurdia  inc",
+        "stichting vrienden van laurens pax intrantibus",
+        "nicren n v",
+        "scheepvaartbedrijf absurdia inc",
         "aeoa aeoa inc",
         "ss ss german co",
     ]


### PR DESCRIPTION
- Add functions to set format and storage options of spark dataframes when calling spark namematching save. Example usage: `nm_obj.write().format('parquet').options(**options_dict).save(path)`
- Get rid of np.array_split on pd series future deprecation warning
- Remove any extra whitespace from processed names for n-char indexing.
- Pass thru correct-match column if present in SparkAggregator; useful for accuracy testing.