### PR TITLE
FIX: ensure sklearn and spark tfidf compatibility for sklearn >= 1.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
   # Fix for error ValueError: numpy.ndarray size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject.
   "numpy>=1.20.1",
   "scipy",
-  "scikit-learn>=1.0.0",
+  "scikit-learn<1.5.0",
   "pandas>=1.1.0,!=1.5.0",
   "jinja2", # for pandas https://pandas.pydata.org/docs/getting_started/install.html#visualization
   "rapidfuzz<3.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
   # Fix for error ValueError: numpy.ndarray size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject.
   "numpy>=1.20.1",
   "scipy",
-  "scikit-learn<1.5.0",
+  "scikit-learn>=1.0.0",
   "pandas>=1.1.0,!=1.5.0",
   "jinja2", # for pandas https://pandas.pydata.org/docs/getting_started/install.html#visualization
   "rapidfuzz<3.0.0",


### PR DESCRIPTION
Note: we are using sklearn v1.4.2 of TfidfTransformer in order to ensure compatibility between the
pandas and spark version of emm. In sklearn v1.5+ TfidfTransformer no longer has the _idf_diag attribute,
needed for the compatibility.