### PR TITLE
FIX: keep gt_entity_id as int64 when no match candidates are added

### DIFF
--- a/emm/indexing/pandas_candidate_selection.py
+++ b/emm/indexing/pandas_candidate_selection.py
@@ -212,6 +212,7 @@ class PandasCandidateSelectionTransformer(TransformerMixin):
             if self.with_no_matches:
                 # change gt_uid column to nullable integer
                 candidates["gt_uid"] = candidates["gt_uid"].replace({NO_MATCH_ID: np.nan}).astype("Int64")
+                candidates["gt_entity_id"] = candidates["gt_entity_id"].replace({NO_MATCH_ID: np.nan}).astype("Int64")
 
             timer.log_param("n", len(X))
 


### PR DESCRIPTION
When adding no-match candidate rows, the value of gt_entity_id is nan.
This fix prevents pandas from converting the column datatype from int into float. 