### PR TITLE
FIX: allow either nullable int or string for gt_entity_id column

### DIFF
--- a/emm/indexing/pandas_candidate_selection.py
+++ b/emm/indexing/pandas_candidate_selection.py
@@ -212,7 +212,8 @@ class PandasCandidateSelectionTransformer(TransformerMixin):
             if self.with_no_matches:
                 # change gt_uid column to nullable integer
                 candidates["gt_uid"] = candidates["gt_uid"].replace({NO_MATCH_ID: np.nan}).astype("Int64")
-                candidates["gt_entity_id"] = candidates["gt_entity_id"].replace({NO_MATCH_ID: np.nan}).astype("Int64")
+                # change gt_entity_id to either nullable integer or nullable string.
+                candidates["gt_entity_id"] = candidates["gt_entity_id"].convert_dtypes()
 
             timer.log_param("n", len(X))
 


### PR DESCRIPTION
gt_entity_id column should be able to have any format (string, int, float). 
Besides float, allow either nullable int or string for gt_entity_id column.