### PR TITLE
FIX: add preprocess_merge_abbr_v0 str cleaning option for bkw-compatibility

### DIFF
--- a/emm/preprocessing/base_name_preprocessor.py
+++ b/emm/preprocessing/base_name_preprocessor.py
@@ -46,6 +46,16 @@ DEFINED_PIPELINE_DICT = {
         "handle_lower_trim",
         "remove_extra_space",
     ],
+    "preprocess_merge_abbr_v0": [  # preprocess_merge_abbr v0, w/o remove_extra_space, for bkw-compatibility
+        "strip_accents_unicode",
+        "replace_punctuation",
+        "remove_newline",
+        "merge_abbreviations",  # merge all abbreviation
+        "merge_&",
+        "strip_punctuation",
+        "handle_lower_trim",
+        "map_shorthands",
+    ],
     "preprocess_merge_abbr": [
         "strip_accents_unicode",
         "replace_punctuation",


### PR DESCRIPTION
Add preprocess_merge_abbr_v0 string preprocessing option for model bkw-compatibility.

preprocess_merge_abbr_v0 is same as preprocess_merge_abbr v0 w/o remove_extra_space, for model 
bkw-compatibility. This makes it easy to use v1.3 models in emm v2.0 with (near) identical outcomes.