### PR TITLE
Ci test macos

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,9 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python: ['3.8', '3.9', '3.10', '3.11']
-      include:
-        - os: macos-latest
-          python: '3.12'  
+        include:
+          - os: macos-latest
+            python: '3.12'  
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
         include:
           - os: macos-latest
             python: '3.10'  
+      fail-fast: false       
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, ci-test-macos ]
   pull_request:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
         python: ['3.8', '3.9', '3.10', '3.11']
         include:
           - os: macos-latest
-            python: '3.12'  
+            python: '3.10'  
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python }}
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,9 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python: ['3.8', '3.9', '3.10', '3.11']
+      include:
+        - os: macos-latest
+          python: '3.12'  
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "xgboost==2.0.3; sys_platform=='darwin'", # to avoid having to install libomp.dylib for later versions of xgboost
   "sparse-dot-topn>=1.1.1",
   "joblib",
-  "pyarrow",
+  "pyarrow>=6.0.1", # seems to work with spark 3.1.2 - 3.3.1
   "requests",
   "unidecode"
 ]
@@ -43,7 +43,7 @@ spark = [
   # https://issues.apache.org/jira/browse/SPARK-41718
   # 3.4 is needed for python 3.11
   # https://github.com/apache/spark/pull/38987
-  "pyspark>=3.3.4; python_version < '3.11'",
+  "pyspark>=3.1; python_version < '3.11'",
   "numpy<1.24.0",
 ]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
   "cleanco>=2.2",
   # It is important to fix the version of xgboost for reproducible classification scores
   "xgboost",
+  "xgboost==2.0.3; platform_system=='MacOS'"
   "sparse-dot-topn>=1.1.1",
   "joblib",
   "pyarrow>=6.0.1", # seems to work with spark 3.1.2 - 3.3.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "cleanco>=2.2",
   # It is important to fix the version of xgboost for reproducible classification scores
   "xgboost",
-  "xgboost==2.0.3; platform_system=='MacOS'",
+  "xgboost==2.0.3; platform_system=='darwin'",
   "sparse-dot-topn>=1.1.1",
   "joblib",
   "pyarrow>=6.0.1", # seems to work with spark 3.1.2 - 3.3.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "cleanco>=2.2",
   # It is important to fix the version of xgboost for reproducible classification scores
   "xgboost",
-  "xgboost==2.0.3; platform_system=='MacOS'"
+  "xgboost==2.0.3; platform_system=='MacOS'",
   "sparse-dot-topn>=1.1.1",
   "joblib",
   "pyarrow>=6.0.1", # seems to work with spark 3.1.2 - 3.3.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "cleanco>=2.2",
   # It is important to fix the version of xgboost for reproducible classification scores
   "xgboost",
-  "xgboost==2.0.3; platform_system=='darwin'",
+  "xgboost==2.0.3; sys_platform=='darwin'",
   "sparse-dot-topn>=1.1.1",
   "joblib",
   "pyarrow>=6.0.1", # seems to work with spark 3.1.2 - 3.3.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "cleanco>=2.2",
   # It is important to fix the version of xgboost for reproducible classification scores
   "xgboost",
-  "xgboost==2.0.3; sys_platform=='darwin'",
+  "xgboost==2.0.3; sys_platform=='darwin'", # to avoid having to install libomp.dylib for later versions of xgboost
   "sparse-dot-topn>=1.1.1",
   "joblib",
   "pyarrow>=6.0.1", # seems to work with spark 3.1.2 - 3.3.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "xgboost==2.0.3; sys_platform=='darwin'", # to avoid having to install libomp.dylib for later versions of xgboost
   "sparse-dot-topn>=1.1.1",
   "joblib",
-  "pyarrow>=6.0.1", # seems to work with spark 3.1.2 - 3.3.1
+  "pyarrow",
   "requests",
   "unidecode"
 ]
@@ -43,7 +43,7 @@ spark = [
   # https://issues.apache.org/jira/browse/SPARK-41718
   # 3.4 is needed for python 3.11
   # https://github.com/apache/spark/pull/38987
-  "pyspark>=3.1; python_version < '3.11'",
+  "pyspark>=3.3.4; python_version < '3.11'",
   "numpy<1.24.0",
 ]
 dev = [


### PR DESCRIPTION
- Added macos with python 3.10 to the cicd testing configurations
- Pinned xgboost to 2.0.3 for Darwin to avoid having to install libomp
- Updated the actions setup-python (v4->v5), cache (v3->v4) to avoid a warning about a newer version of node.js which exists on newer nodes (20) 
- Cancelled fail-fast for testing strategy