### PR TITLE
Update create_training_name_pairs to pass additional arguments to prepare_name_pairs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   push:
-    branches: [ main, update_create_training_name_pairs]
+    branches: [ main ]
   pull_request:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, update_create_training_name_pairs]
   pull_request:
 
 jobs:

--- a/emm/pipeline/pandas_entity_matching.py
+++ b/emm/pipeline/pandas_entity_matching.py
@@ -312,6 +312,7 @@ class PandasEntityMatching(BaseEntityMatching):
         n_train_ids: int = -1,
         random_seed: int = 42,
         drop_duplicate_candidates: bool | None = None,
+        **kwargs,
     ) -> pd.DataFrame:
         """Create name-pairs for training from positive names that match to the ground truth.
 
@@ -333,6 +334,7 @@ class PandasEntityMatching(BaseEntityMatching):
             drop_duplicate_candidates: if True drop any duplicate training candidates and keep just one,
                             if available keep the correct match. Recommended for string-similarity models, eg. with
                             without_rank_features=True. default is False.
+            kwargs: extra key-word arguments meant to be passed to prepare_name_pairs_pd.
 
         Returns:
             pandas dataframe with name-pair candidates to be used for training.
@@ -383,6 +385,7 @@ class PandasEntityMatching(BaseEntityMatching):
             create_negative_sample_fraction=create_negative_sample_fraction,
             positive_set_col=self.parameters.get("positive_set_col", "positive_set"),
             random_seed=random_seed,
+            **kwargs,
         )
 
     def fit_classifier(

--- a/emm/pipeline/spark_entity_matching.py
+++ b/emm/pipeline/spark_entity_matching.py
@@ -365,6 +365,7 @@ class SparkEntityMatching(
             drop_duplicate_candidates: if True drop any duplicate training candidates and keep just one,
                             if available keep the correct match. Recommended for string-similarity models, eg. with
                             without_rank_features=True. default is False.
+            kwargs: extra key-word arguments meant to be passed to prepare_name_pairs_pd.                
 
         Returns:
             pandas dataframe with name-pair candidates to be used for training.

--- a/emm/pipeline/spark_entity_matching.py
+++ b/emm/pipeline/spark_entity_matching.py
@@ -47,8 +47,9 @@ from emm.preprocessing.spark_preprocessor import SparkPreprocessor
 from emm.supervised_model.base_supervised_model import train_model
 from emm.supervised_model.spark_supervised_model import SparkSupervisedLayerEstimator
 
-if TYPE_CHECKING: 
+if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
+
     from pyspark.ml import Pipeline, PipelineModel
 
 

--- a/emm/pipeline/spark_entity_matching.py
+++ b/emm/pipeline/spark_entity_matching.py
@@ -20,14 +20,11 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Any, Callable, Literal, Mapping
+from collections.abc import Callable, Mapping
+from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 import pandas as pd
-from pyspark.ml.util import DefaultParamsReadable, DefaultParamsWritable
-from pyspark.sql import DataFrame, SparkSession
-from pyspark.sql import functions as F
-
 from emm.aggregation.base_entity_aggregation import BaseEntityAggregation
 from emm.aggregation.spark_entity_aggregation import SparkEntityAggregation
 from emm.data.prepare_name_pairs import prepare_name_pairs
@@ -46,6 +43,9 @@ from emm.preprocessing.base_name_preprocessor import AbstractPreprocessor
 from emm.preprocessing.spark_preprocessor import SparkPreprocessor
 from emm.supervised_model.base_supervised_model import train_model
 from emm.supervised_model.spark_supervised_model import SparkSupervisedLayerEstimator
+from pyspark.ml.util import DefaultParamsReadable, DefaultParamsWritable
+from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql import functions as F
 
 if TYPE_CHECKING:
     from pyspark.ml import Pipeline, PipelineModel
@@ -269,7 +269,9 @@ class SparkEntityMatching(
         # We repartition in order to have at least 200, to have a nice parallel computation
         # (assuming memory is not an issue here) and nice parallelism for joins in transform() later on.
         # We usually have less than 200 partitions in case the ground_truth is not that long.
-        ground_truth_df, self.n_ground_truth = auto_repartitioning(ground_truth_df, self.parameters["partition_size"])
+        ground_truth_df, self.n_ground_truth = auto_repartitioning(
+            ground_truth_df, self.parameters["partition_size"]
+        )
         ground_truth_df = check_uid(ground_truth_df, self.parameters["uid_col"])
         ground_truth_df = self._normalize_column_names(ground_truth_df)
         self.model = self.pipeline.fit(ground_truth_df)
@@ -326,7 +328,9 @@ class SparkEntityMatching(
             cols_to_keep = names_df.columns
             cols_to_drop = [c for c in matched_df.columns if c not in cols_to_keep]
             cols_to_drop = [
-                c for c in cols_to_drop if not re.match(pattern, c) and not c.endswith("_score") and c != "preprocessed"
+                c
+                for c in cols_to_drop
+                if not re.match(pattern, c) and not c.endswith("_score") and c != "preprocessed"
             ]
             matched_df = matched_df.drop(*cols_to_drop)
             logger.debug(f"Dropping columns: {cols_to_drop}")
@@ -365,7 +369,7 @@ class SparkEntityMatching(
             drop_duplicate_candidates: if True drop any duplicate training candidates and keep just one,
                             if available keep the correct match. Recommended for string-similarity models, eg. with
                             without_rank_features=True. default is False.
-            kwargs: extra key-word arguments meant to be passed to prepare_name_pairs_pd.                
+            kwargs: extra key-word arguments meant to be passed to prepare_name_pairs_pd.
 
         Returns:
             pandas dataframe with name-pair candidates to be used for training.
@@ -494,7 +498,9 @@ class SparkEntityMatching(
         # keep both stages for re-adding later (also in case of do_training=False).
         if self.parameters.get("supervised_on", False):
             self.model.stages.pop(2)
-        aggregation_model = self.model.stages.pop() if self.parameters.get("aggregation_layer", False) else None
+        aggregation_model = (
+            self.model.stages.pop() if self.parameters.get("aggregation_layer", False) else None
+        )
         # remove any existing untrained model 'X', no longer needed.
         if isinstance(self.supervised_models, dict):
             self.supervised_models.pop("X", None)
@@ -583,7 +589,9 @@ class SparkEntityMatching(
         # reinsert again below with new sklearn model included.
         if self.parameters.get("supervised_on", False):
             self.model.stages.pop(2)
-        aggregation_model = self.model.stages.pop() if self.parameters.get("aggregation_layer", False) else None
+        aggregation_model = (
+            self.model.stages.pop() if self.parameters.get("aggregation_layer", False) else None
+        )
 
         # add new supervised model to self.supervised_models
         # self.supervised_models contains all trained and untrained sklearn models

--- a/emm/pipeline/spark_entity_matching.py
+++ b/emm/pipeline/spark_entity_matching.py
@@ -343,6 +343,7 @@ class SparkEntityMatching(
         n_train_ids=-1,
         random_seed=42,
         drop_duplicate_candidates: bool | None = None,
+        **kwargs,
     ) -> pd.DataFrame:
         """Create name-pairs for training from positive names that match to the ground truth.
 
@@ -409,6 +410,7 @@ class SparkEntityMatching(
             create_negative_sample_fraction=create_negative_sample_fraction,
             positive_set_col=self.parameters.get("positive_set_col", "positive_set"),
             random_seed=random_seed,
+            **kwargs,
         )
 
     def fit_classifier(

--- a/emm/pipeline/spark_entity_matching.py
+++ b/emm/pipeline/spark_entity_matching.py
@@ -20,7 +20,6 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
@@ -48,6 +47,8 @@ from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql import functions as F
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
     from pyspark.ml import Pipeline, PipelineModel
 
 

--- a/emm/pipeline/spark_entity_matching.py
+++ b/emm/pipeline/spark_entity_matching.py
@@ -47,7 +47,7 @@ from emm.preprocessing.spark_preprocessor import SparkPreprocessor
 from emm.supervised_model.base_supervised_model import train_model
 from emm.supervised_model.spark_supervised_model import SparkSupervisedLayerEstimator
 
-if TYPE_CHECKING:
+if TYPE_CHECKING: 
     from collections.abc import Callable, Mapping
     from pyspark.ml import Pipeline, PipelineModel
 


### PR DESCRIPTION
### Background
The classes `SparkEntityMatching` and `PandasEntityMatching` have a method `create_training_name_pairs` which then calls either `prepare_name_pairs` or `prepare_name_pairs_pd`. The issue is that `prepare_name_pairs_pd` accepts parameters which are not exposed through `create_training_name_pairs` like _drop_samename_nomatch_.

### Changes
- Added `kwargs` to both spark and pandas versions of `create_training_name_pairs` to allow them to pass arguments to `prepare_name_pairs_pd`
- Some formatting changed by ruff.