### PR TITLE
FIX: Refactor prepare_name_pairs_pd to pass arguments to create_positive_negative_samples

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, refactor_prepare_name_pairs ]
   pull_request:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   push:
-    branches: [ main, refactor_prepare_name_pairs ]
+    branches: [ main ]
   pull_request:
 
 jobs:

--- a/emm/data/prepare_name_pairs.py
+++ b/emm/data/prepare_name_pairs.py
@@ -71,6 +71,8 @@ def prepare_name_pairs_pd(
                         For matching name-pairs entity_id == gt_entity_id.
         positive_set_col: column that specifies which candidates remain positive and which become negative,
                         default is "positive_set".
+        correct_col: column that indicates a correct match, default is "correct".
+                        For entity_id == gt_entity_id the column value is "correct".
         uid_col: uid column for names to match, default is "uid".
         random_seed: random seed for selection of negative names, default is 42.
     """

--- a/emm/data/prepare_name_pairs.py
+++ b/emm/data/prepare_name_pairs.py
@@ -111,8 +111,8 @@ def prepare_name_pairs_pd(
     # - happens with one correct/positive case, we just pick the correct one
     if drop_duplicate_candidates:
         candidates_pd = candidates_pd.sort_values(
-            ["uid", "gt_preprocessed", correct_col], ascending=False
-        ).drop_duplicates(subset=["uid", "gt_preprocessed"], keep="first")
+            [uid_col, "gt_preprocessed", correct_col], ascending=False
+        ).drop_duplicates(subset=[uid_col, "gt_preprocessed"], keep="first")
     # Similar, for a training set remove all equal names that are not considered a match.
     # This can happen a lot in actual data, e.g. with franchises that are independent but have the same name.
     # It's a true effect in data, but this screws up our intuitive notion that identical names should be related.
@@ -134,7 +134,7 @@ def prepare_name_pairs_pd(
         # is referred to in: resources/data/howto_create_unittest_sample_namepairs.txt
         # create negative sample and rerank negative candidates
         # this drops, in part, the negative correct candidates
-        candidates_pd = create_positive_negative_samples(candidates_pd, correct_col=correct_col)
+        candidates_pd = create_positive_negative_samples(candidates_pd, correct_col=correct_col, uid_col=uid_col)
 
     # It could be that we dropped all candidates, so we need to re-introduce the no-candidate rows
     names_to_match_after = candidates_pd[names_to_match_cols].drop_duplicates()

--- a/emm/data/prepare_name_pairs.py
+++ b/emm/data/prepare_name_pairs.py
@@ -142,7 +142,9 @@ def prepare_name_pairs_pd(
         # is referred to in: resources/data/howto_create_unittest_sample_namepairs.txt
         # create negative sample and rerank negative candidates
         # this drops, in part, the negative correct candidates
-        candidates_pd = create_positive_negative_samples(candidates_pd, uid_col=uid_col, correct_col=correct_col)
+        candidates_pd = create_positive_negative_samples(
+            candidates_pd, uid_col=uid_col, correct_col=correct_col, positive_set_col=positive_set_col
+        )
 
     # It could be that we dropped all candidates, so we need to re-introduce the no-candidate rows
     names_to_match_after = candidates_pd[names_to_match_cols].drop_duplicates()

--- a/emm/pipeline/pandas_entity_matching.py
+++ b/emm/pipeline/pandas_entity_matching.py
@@ -386,6 +386,9 @@ class PandasEntityMatching(BaseEntityMatching):
             positive_set_col=self.parameters.get("positive_set_col", "positive_set"),
             correct_col=self.parameters.get("correct_col", "correct"),
             uid_col=self.parameters.get("uid_col", "uid"),
+            gt_uid_col=self.parameters.get("gt_uid_col", "gt_uid"),
+            preprocessed_col=self.parameters.get("preprocessed_col", "preprocessed"),
+            gt_preprocessed_col=self.parameters.get("gt_preprocessed_col", "gt_preprocessed"),
             random_seed=random_seed,
             **kwargs,
         )

--- a/emm/pipeline/pandas_entity_matching.py
+++ b/emm/pipeline/pandas_entity_matching.py
@@ -384,6 +384,7 @@ class PandasEntityMatching(BaseEntityMatching):
             else drop_duplicate_candidates,
             create_negative_sample_fraction=create_negative_sample_fraction,
             positive_set_col=self.parameters.get("positive_set_col", "positive_set"),
+            correct_col=self.parameters.get("correct_col", "correct"),
             random_seed=random_seed,
             **kwargs,
         )

--- a/emm/pipeline/pandas_entity_matching.py
+++ b/emm/pipeline/pandas_entity_matching.py
@@ -385,6 +385,7 @@ class PandasEntityMatching(BaseEntityMatching):
             create_negative_sample_fraction=create_negative_sample_fraction,
             positive_set_col=self.parameters.get("positive_set_col", "positive_set"),
             correct_col=self.parameters.get("correct_col", "correct"),
+            uid_col=self.parameters.get("uid_col", "uid"),
             random_seed=random_seed,
             **kwargs,
         )

--- a/emm/pipeline/spark_entity_matching.py
+++ b/emm/pipeline/spark_entity_matching.py
@@ -412,6 +412,11 @@ class SparkEntityMatching(
             else drop_duplicate_candidates,
             create_negative_sample_fraction=create_negative_sample_fraction,
             positive_set_col=self.parameters.get("positive_set_col", "positive_set"),
+            correct_col=self.parameters.get("correct_col", "correct"),
+            uid_col=self.parameters.get("uid_col", "uid"),
+            gt_uid_col=self.parameters.get("gt_uid_col", "gt_uid"),
+            preprocessed_col=self.parameters.get("preprocessed_col", "preprocessed"),
+            gt_preprocessed_col=self.parameters.get("gt_preprocessed_col", "gt_preprocessed"),
             random_seed=random_seed,
             **kwargs,
         )


### PR DESCRIPTION
`prepare_name_pairs_pd` is not passing the column names for _uid_, _correct_, and _positive set_ columns to `create_positive_negative_samples`.

In this pr:
- _correct_col_, _uid_col_, _gt_uid_col_, _preprocessed_col_, _gt_preprocessed_col_ become parameters for `prepare_name_pairs_pd`
- the corresponding hardcoded values of `prepare_name_pairs_pd` become default values for these columns and are replaced by the variables
- the above columns are passed from `create_training_name_pairs` to `prepare_name_pairs` for both pandas and spark versions
- _uid_col_, _correct_col_, _positive_set_col_ are passed from `prepare_name_pairs_pd` to `create_positive_negative_samples` 